### PR TITLE
improved initialization for large towns

### DIFF
--- a/common/src/main/resources/trafficsimulation.conf
+++ b/common/src/main/resources/trafficsimulation.conf
@@ -20,6 +20,9 @@ trafficsimulation {
   }
   time.seconds = 30
   warmup.seconds = 10
+  resolve_neighbours.retries = 12
+  resolve_neighbours.delay.seconds = 5
+  resolve_neighbours.timeout.seconds = 30
 }
 akka {
   actor {

--- a/common/src/main/scala/miss/supervisor/Supervisor.scala
+++ b/common/src/main/scala/miss/supervisor/Supervisor.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.Config
 import miss.cityvisualization.CityVisualizerActor
 import miss.common.SerializableMessage
 import miss.supervisor.Supervisor.{Data, State}
-import miss.trafficsimulation.actors.AreaActor.EndWarmUpPhase
+import miss.trafficsimulation.actors.AreaActor.{AreaRoadDefinition, EndWarmUpPhase}
 import miss.trafficsimulation.actors._
 import miss.trafficsimulation.roads.RoadDirection.RoadDirection
 import miss.trafficsimulation.roads._
@@ -302,5 +302,5 @@ object Supervisor {
 
 case class RoadDefinition(roadId: RoadId, direction: RoadDirection) {
   def toAreaRoadDefinition(outgoingActorRef: ActorRef, prevAreaActorRef: ActorRef): AreaRoadDefinition =
-    AreaRoadDefinition(roadId, direction, outgoingActorRef, prevAreaActorRef)
+    AreaRoadDefinition(roadId, direction, outgoingActorRef.path, prevAreaActorRef.path)
 }

--- a/common/src/main/scala/miss/supervisor/Supervisor.scala
+++ b/common/src/main/scala/miss/supervisor/Supervisor.scala
@@ -228,7 +228,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
   }
 
   private def handleRemotingEvents: StateFunction = {
-    case Event(ev@DisassociatedEvent(_, _, _), SupervisorData(workers, actors, _)) =>
+    case Event(ev: DisassociatedEvent, SupervisorData(workers, actors, _)) =>
       log.error(s"Got DisassociatedEvent: ${ev.toString}. Shutting down.")
       for (i <- 0 until rows) {
         for (j <- 0 until cols) {

--- a/common/src/main/scala/miss/supervisor/Supervisor.scala
+++ b/common/src/main/scala/miss/supervisor/Supervisor.scala
@@ -1,7 +1,7 @@
 package miss.supervisor
 
 import akka.actor._
-import akka.remote.RemoteScope
+import akka.remote._
 import com.typesafe.config.Config
 import miss.cityvisualization.CityVisualizerActor
 import miss.common.SerializableMessage
@@ -63,7 +63,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
       }
   }
 
-  when(WarmUp) {
+  when(WarmUp)(handleRemotingEvents orElse {
     case Event(TimeFrameUpdate(x, y, newTimeFrame), SupervisorData(_, _, cityVisualizer)) =>
       log.debug(s"Got TimeFrameUpdate from actor $x, $y: frame $newTimeFrame")
       cityVisualizer.foreach(ar => ar ! CityVisualizationUpdate(x, y, newTimeFrame))
@@ -78,9 +78,9 @@ class Supervisor(config: Config) extends FSM[State, Data] {
       }
       setTimer("simulation-done-timer", SimulationDone, simulationTimeSeconds seconds)
       goto(Working)
-  }
+  })
 
-  when(Working) {
+  when(Working)(handleRemotingEvents orElse {
     case Event(StartVisualization(x, y), SupervisorData(_, actors, _)) =>
       val visualizer = sender()
       actors(x)(y) ! VisualizationStartRequest(visualizer)
@@ -107,7 +107,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
         }
       }
       goto(EndingSimulation) using TearDownData(workers, actorsToTerminate.toSet, Map[(Int, Int), Long]())
-  }
+  })
 
   when(EndingSimulation) {
     case Event(SimulationResult(x, y, computedFrames), data@TearDownData(workers, actorsToTerminate, computedFramesByArea)) if actorsToTerminate.size > 1 =>
@@ -231,6 +231,20 @@ class Supervisor(config: Config) extends FSM[State, Data] {
     }
     log.info("Done sending StartSimulation")
     actors
+  }
+
+  private def handleRemotingEvents: StateFunction = {
+    case Event(ev@DisassociatedEvent(_, _, _), SupervisorData(workers, actors, _)) =>
+      log.error(s"Got DisassociatedEvent: ${ev.toString}. Shutting down.")
+      for (i <- 0 until rows) {
+        for (j <- 0 until cols) {
+          val actor = actors(i)(j)
+          actor ! PoisonPill
+        }
+      }
+      workers.foreach(worker => worker ! PoisonPill)
+      context.system.terminate()
+      stop
   }
 
 }

--- a/common/src/main/scala/miss/supervisor/Supervisor.scala
+++ b/common/src/main/scala/miss/supervisor/Supervisor.scala
@@ -169,6 +169,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
     val workersPool = buildWorkersPool(workers)
 
     // Create area actors
+    log.info("Deploying actors...")
     for (i <- 0 until rows) {
       for (j <- 0 until cols) {
         val worker = workersPool.dequeue()
@@ -178,6 +179,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
           s"AreaActor_${i}_$j")
       }
     }
+    log.info("Done deploying actors")
     // Generate area roads definitions
     for (i <- 0 until verticalRoadsNum) {
       val direction = if (i % 2 == 0) RoadDirection.NS else RoadDirection.SN
@@ -188,6 +190,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
       horizontalRoadDefs(j) = RoadDefinition(RoadId(verticalRoadsNum + j), direction)
     }
     // Start simulation
+    log.info("Sending StartSimulation commands...")
     for (i <- 0 until rows) {
       for (j <- 0 until cols) {
         val areaVerticalRoadDefs = ListBuffer[AreaRoadDefinition]()
@@ -226,6 +229,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
         actors(i)(j) ! StartSimulation(areaVerticalRoadDefs.toList, areaHorizontalRoadDefs.toList, i, j)
       }
     }
+    log.info("Done sending StartSimulation")
     actors
   }
 

--- a/common/src/main/scala/miss/supervisor/Supervisor.scala
+++ b/common/src/main/scala/miss/supervisor/Supervisor.scala
@@ -23,6 +23,7 @@ class Supervisor(config: Config) extends FSM[State, Data] {
   import AreaActor.{EndSimulation, StartSimulation, VisualizationStartRequest, VisualizationStopRequest}
   import CityVisualizerActor._
   import Supervisor._
+  import context.dispatcher
 
   private val cols = config.getInt("trafficsimulation.city.cols")
   private val rows = config.getInt("trafficsimulation.city.rows")
@@ -127,21 +128,14 @@ class Supervisor(config: Config) extends FSM[State, Data] {
 
       log.info(s"Simulation done. Computed frames: ${minEntry._2}, min FPS: $minFps, max FPS: $maxFps, avg FPS: $avgFps")
       workers.foreach(worker => worker ! Terminate)
-      goto(TerminatingWorkers) using data.copy(actorsToTerminate = Set())
+      context.system.scheduler.scheduleOnce(2 seconds, self, TerminateSupervisor)
+      goto(Terminating)
   }
 
-  when(TerminatingWorkers) {
-    case Event(UnregisterWorker, data@TearDownData(workers, _, _)) =>
-      val senderActor = sender()
-      log.debug("Removing " + senderActor.toString())
-      if (workers.size > 1) {
-        stay using data.copy(workers = workers.filter(_ != senderActor))
-      }
-      else {
-        context.system.terminate
-        stop
-      }
-    case Event(_, _) => stay
+  when(Terminating) {
+    case Event(TerminateSupervisor, _) =>
+      context.system.terminate()
+      stop
   }
 
   private def allWorkersRegistered(workers: List[ActorRef]): Boolean = {
@@ -257,7 +251,7 @@ object Supervisor {
 
   case object RegisterWorker extends SerializableMessage
 
-  case object UnregisterWorker extends SerializableMessage
+  case object TerminateSupervisor
 
   case class StartVisualization(x: Int, y: Int)
 
@@ -292,8 +286,7 @@ object Supervisor {
 
   case object EndingSimulation extends State
 
-  case object TerminatingWorkers extends State
-
+  case object Terminating extends State
 
   // Data
   sealed trait Data

--- a/common/src/main/scala/miss/trafficsimulation/actors/AreaActor.scala
+++ b/common/src/main/scala/miss/trafficsimulation/actors/AreaActor.scala
@@ -1,10 +1,11 @@
 package miss.trafficsimulation.actors
 
-import akka.actor.{ActorRef, FSM, Props, Stash}
+import akka.actor.{ActorPath, ActorRef, ActorSelection, FSM, Props, Stash}
 import com.typesafe.config.Config
 import miss.common.SerializableMessage
 import miss.supervisor.Supervisor
 import miss.trafficsimulation.actors.AreaActor.{Data, State}
+import miss.trafficsimulation.roads.RoadDirection._
 import miss.trafficsimulation.roads._
 import miss.visualization.VisualizationActor.TrafficState
 
@@ -19,11 +20,16 @@ class AreaActor(config: Config) extends FSM[State, Data] with Stash {
 
   startWith(Initialized, EmptyData)
 
+  private def resolveActor(actorPath: ActorPath): ActorSelection = this.context.actorSelection(actorPath)
+
   when(Initialized) {
     case Event(StartSimulation(verticalRoadsDefs, horizontalRoadsDefs, x, y), EmptyData) =>
       val supervisor = sender()
       log.info(s"Actor ($x, $y) starting simulation...")
-      val area = new Area(verticalRoadsDefs, horizontalRoadsDefs, config)
+      val verticalRoadsData = verticalRoadsDefs.map(r => AreaRoadData(r.roadId, r.direction, resolveActor(r.outgoingActorPath), resolveActor(r.prevAreaActorPath)))
+      val horizontalRoadsData = horizontalRoadsDefs.map(r => AreaRoadData(r.roadId, r.direction, resolveActor(r.outgoingActorPath), resolveActor(r.prevAreaActorPath)))
+
+      val area = new Area(verticalRoadsData, horizontalRoadsData, config)
       // sending initial available road space info
       sendAvailableRoadSpaceInfo(area)
       self ! ReadyForComputation(0)
@@ -72,22 +78,22 @@ class AreaActor(config: Config) extends FSM[State, Data] with Stash {
 
       // sending outgoing traffic
       val messagesSent = mutable.Map(area.outgoingActorsAndRoadIds.map({
-        case (a: ActorRef, r: RoadId) => (a, r) -> false
+        case (a: ActorSelection, r: RoadId) => (a, r) -> false
       }): _*)
       outgoingTraffic groupBy {
-        case (actorRef, roadId, _) => (actorRef, roadId)
+        case (actor, roadId, _) => (actor, roadId)
       } foreach {
-        case ((actorRef, roadId), list) =>
-          log.debug(s"Sending to $actorRef; roadId: $roadId; traffic: $list")
-          messagesSent((actorRef, roadId)) = true
-          actorRef ! OutgoingTrafficInfo(roadId, area.currentTimeFrame, list map {
+        case ((actor, roadId), list) =>
+          log.debug(s"Sending to $actor; roadId: $roadId; traffic: $list")
+          messagesSent((actor, roadId)) = true
+          actor ! OutgoingTrafficInfo(roadId, area.currentTimeFrame, list map {
             case (_, _, vac) => vac
           })
       }
       messagesSent foreach {
-        case ((actorRef, roadId), false) =>
-          log.debug(s"Sending to $actorRef; roadId: $roadId; traffic: No traffic")
-          actorRef ! OutgoingTrafficInfo(roadId, area.currentTimeFrame, List())
+        case ((actor, roadId), false) =>
+          log.debug(s"Sending to $actor; roadId: $roadId; traffic: No traffic")
+          actor ! OutgoingTrafficInfo(roadId, area.currentTimeFrame, List())
         case _ =>
       }
 
@@ -124,9 +130,9 @@ class AreaActor(config: Config) extends FSM[State, Data] with Stash {
   def sendAvailableRoadSpaceInfo(area: Area) = {
     val availableRoadSpaceInfoList = area.getAvailableSpaceInfo
     availableRoadSpaceInfoList foreach {
-      case ((actorRef, roadId, list)) =>
-        log.debug(s"Sending to $actorRef; roadId: $roadId; available space: $list")
-        actorRef ! AvailableRoadspaceInfo(roadId, area.currentTimeFrame, list)
+      case ((actor, roadId, list)) =>
+        log.debug(s"Sending to $actor; roadId: $roadId; available space: $list")
+        actor ! AvailableRoadspaceInfo(roadId, area.currentTimeFrame, list)
       case _ =>
     }
   }
@@ -134,9 +140,9 @@ class AreaActor(config: Config) extends FSM[State, Data] with Stash {
   def sendAvailableRoadSpaceInfo(area: Area, updatedRoads: Map[RoadId, Long] = Map()) = {
     val availableRoadSpaceInfoList = area.getAvailableSpaceInfo
     availableRoadSpaceInfoList foreach {
-      case ((actorRef, roadId, list)) if updatedRoads.contains(roadId) =>
-        log.debug(s"Sending to $actorRef; roadId: $roadId; timeframe: ${updatedRoads(roadId)} available space: $list")
-        actorRef ! AvailableRoadspaceInfo(roadId, updatedRoads(roadId), list)
+      case ((actor, roadId, list)) if updatedRoads.contains(roadId) =>
+        log.debug(s"Sending to $actor; roadId: $roadId; timeframe: ${updatedRoads(roadId)} available space: $list")
+        actor ! AvailableRoadspaceInfo(roadId, updatedRoads(roadId), list)
       case _ =>
     }
   }
@@ -147,6 +153,8 @@ class AreaActor(config: Config) extends FSM[State, Data] with Stash {
 object AreaActor {
 
   def props(config: Config): Props = Props(classOf[AreaActor], config)
+
+  case class AreaRoadDefinition(roadId: RoadId, direction: RoadDirection, outgoingActorPath: ActorPath, prevAreaActorPath: ActorPath) extends SerializableMessage
 
   // Messages:
 

--- a/common/src/main/scala/miss/trafficsimulation/actors/AreaActor.scala
+++ b/common/src/main/scala/miss/trafficsimulation/actors/AreaActor.scala
@@ -140,6 +140,8 @@ class AreaActor(config: Config) extends FSM[State, Data] with Stash {
       case _ =>
     }
   }
+
+  log.info(s"Actor ${self.path} initialized")
 }
 
 object AreaActor {

--- a/common/src/main/scala/miss/trafficsimulation/roads/Road.scala
+++ b/common/src/main/scala/miss/trafficsimulation/roads/Road.scala
@@ -1,6 +1,6 @@
 package miss.trafficsimulation.roads
 
-import akka.actor.ActorSelection
+import akka.actor.ActorRef
 import miss.trafficsimulation.roads.LightsDirection.{Horizontal, LightsDirection, Vertical}
 import miss.trafficsimulation.roads.RoadDirection.{EW, NS, RoadDirection, SN, WE}
 import miss.trafficsimulation.traffic.MoveDirection.{GoStraight, SwitchLaneLeft, SwitchLaneRight, Turn}
@@ -9,13 +9,13 @@ import miss.trafficsimulation.traffic._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
-case class Road(id: RoadId, direction: RoadDirection, elems: List[RoadElem], prevAreaActor: ActorSelection, nextAreaRoadSegment: NextAreaRoadSegment)
+case class Road(id: RoadId, direction: RoadDirection, elems: List[RoadElem], prevAreaActor: ActorRef, nextAreaRoadSegment: NextAreaRoadSegment)
 
 case class RoadId(id: Int)
 
 sealed trait RoadElem
 
-case class NextAreaRoadSegment(roadId: RoadId, actor: ActorSelection, lanesCount: Int) extends RoadElem {
+case class NextAreaRoadSegment(roadId: RoadId, actor: ActorRef, lanesCount: Int) extends RoadElem {
   private val carsSentSinceUpdate: ListBuffer[Int] = ListBuffer.fill(lanesCount)(0)
   private var availableSpacePerLane: List[Int] = List.fill(lanesCount)(0)
   private var lastUpdateTimeFrame: Long = 0
@@ -298,8 +298,8 @@ class RoadSegment(val roadId: RoadId,
     Math.min(maxPossible, maxVelocity)
   }
 
-  def simulate(lightsDirection: LightsDirection, timeFrame: Long): List[(ActorSelection, RoadId, VehicleAndCoordinates)] = {
-    val vehiclesAndCoordinatesOutOfArea = ListBuffer[(ActorSelection, RoadId, VehicleAndCoordinates)]()
+  def simulate(lightsDirection: LightsDirection, timeFrame: Long): List[(ActorRef, RoadId, VehicleAndCoordinates)] = {
+    val vehiclesAndCoordinatesOutOfArea = ListBuffer[(ActorRef, RoadId, VehicleAndCoordinates)]()
 
     for (vac <- vehicleIterator(timeFrame - 1)) {
       val move = vac.vehicle.move(calculatePossibleMoves(vac, lightsDirection))

--- a/common/src/main/scala/miss/worker/WorkerActor.scala
+++ b/common/src/main/scala/miss/worker/WorkerActor.scala
@@ -3,7 +3,7 @@ package miss.worker
 import akka.actor.{FSM, Props}
 import akka.remote.{AssociationErrorEvent, DisassociatedEvent}
 import miss.common.SerializableMessage
-import miss.supervisor.Supervisor.{RegisterWorker, UnregisterWorker}
+import miss.supervisor.Supervisor.RegisterWorker
 import miss.worker.WorkerActor.{Data, State}
 
 import scala.concurrent.duration._
@@ -36,8 +36,7 @@ class WorkerActor(supervisorPath: String, retryIntervalSeconds: Long) extends FS
 
   when(Working) {
     case Event(Terminate, _) =>
-      log.info("Sending UnregisterWorker to supervisor")
-      supervisor ! UnregisterWorker
+      log.info("Got Terminate.")
       context.system.scheduler.scheduleOnce(5 seconds, self, TerminateSystem)
       context.system.eventStream.unsubscribe(self, classOf[DisassociatedEvent])
       goto(Terminating)

--- a/common/src/test/scala/miss/trafficsimulation/roads/AreaSpecification.scala
+++ b/common/src/test/scala/miss/trafficsimulation/roads/AreaSpecification.scala
@@ -10,14 +10,14 @@ import org.specs2.mutable.Specification
 class AreaSpecification extends Specification {
   "Area" should {
     "create proper roads" in {
-      val road1 = AreaRoadDefinition(RoadId(1), NS, null, null)
-      val road2 = AreaRoadDefinition(RoadId(2), SN, null, null)
-      val road3 = AreaRoadDefinition(RoadId(3), EW, null, null)
-      val road4 = AreaRoadDefinition(RoadId(4), WE, null, null)
-      val road5 = AreaRoadDefinition(RoadId(5), NS, null, null)
-      val road6 = AreaRoadDefinition(RoadId(6), SN, null, null)
-      val road7 = AreaRoadDefinition(RoadId(7), EW, null, null)
-      val road8 = AreaRoadDefinition(RoadId(8), WE, null, null)
+      val road1 = AreaRoadData(RoadId(1), NS, null, null)
+      val road2 = AreaRoadData(RoadId(2), SN, null, null)
+      val road3 = AreaRoadData(RoadId(3), EW, null, null)
+      val road4 = AreaRoadData(RoadId(4), WE, null, null)
+      val road5 = AreaRoadData(RoadId(5), NS, null, null)
+      val road6 = AreaRoadData(RoadId(6), SN, null, null)
+      val road7 = AreaRoadData(RoadId(7), EW, null, null)
+      val road8 = AreaRoadData(RoadId(8), WE, null, null)
 
       val area = new Area(List(road1, road2, road5, road6),
         List(road3, road4, road7, road8), ConfigFactory.load("road_creation.conf"))
@@ -184,10 +184,10 @@ class AreaSpecification extends Specification {
   }
 
   private def createTestArea: Area = {
-    val road1 = AreaRoadDefinition(RoadId(1), NS, null, null)
-    val road2 = AreaRoadDefinition(RoadId(2), SN, null, null)
-    val road3 = AreaRoadDefinition(RoadId(3), EW, null, null)
-    val road4 = AreaRoadDefinition(RoadId(4), WE, null, null)
+    val road1 = AreaRoadData(RoadId(1), NS, null, null)
+    val road2 = AreaRoadData(RoadId(2), SN, null, null)
+    val road3 = AreaRoadData(RoadId(3), EW, null, null)
+    val road4 = AreaRoadData(RoadId(4), WE, null, null)
 
     val area = new Area(List(road1, road2),
       List(road3, road4), ConfigFactory.load("simple_area.conf"))
@@ -196,10 +196,10 @@ class AreaSpecification extends Specification {
   }
 
   private def createAnotherTestArea: Area = {
-    val road1 = AreaRoadDefinition(RoadId(1), NS, null, null)
-    val road2 = AreaRoadDefinition(RoadId(2), SN, null, null)
-    val road3 = AreaRoadDefinition(RoadId(3), EW, null, null)
-    val road4 = AreaRoadDefinition(RoadId(4), WE, null, null)
+    val road1 = AreaRoadData(RoadId(1), NS, null, null)
+    val road2 = AreaRoadData(RoadId(2), SN, null, null)
+    val road3 = AreaRoadData(RoadId(3), EW, null, null)
+    val road4 = AreaRoadData(RoadId(4), WE, null, null)
 
     val area = new Area(List(road1, road2),
       List(road3, road4), ConfigFactory.load("another_area.conf"))

--- a/supervisor/src/main/scala/miss/supervisor/SupervisorApp.scala
+++ b/supervisor/src/main/scala/miss/supervisor/SupervisorApp.scala
@@ -1,6 +1,7 @@
 package miss.supervisor
 
 import akka.actor.ActorSystem
+import akka.remote.DisassociatedEvent
 import com.typesafe.config.{Config, ConfigFactory}
 
 object SupervisorApp extends App {
@@ -11,6 +12,7 @@ object SupervisorApp extends App {
   checkEnoughCores(config)
   val actorSystem = ActorSystem("TrafficSimulation", config)
   val supervisor = actorSystem.actorOf(Supervisor.props(config), "Supervisor")
+  actorSystem.eventStream.subscribe(supervisor, classOf[DisassociatedEvent])
   supervisor ! Start
 
   private def checkEnoughCores(config: Config) = {


### PR DESCRIPTION
All actors resolve their neighbors' actorRefs from paths before starting simulation. Fixes #32 
Using resolveOne to check if actors are alive. And got rid of workers unregistration - now they watch for disassociation events.