### PR TITLE
Changed Akka version to 2.4.17

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object CommonSettings {
-  private val AkkaVersion = "2.4.16"
+  private val AkkaVersion = "2.4.17"
 
   val commonDependencies: Seq[ModuleID] = Seq(
     "com.typesafe.akka" %% "akka-actor" % AkkaVersion,


### PR DESCRIPTION
Required for tests with Akka Tracing Tool. Closes #31.